### PR TITLE
Fix arrows deflecting too far

### DIFF
--- a/src/main/java/io/github/togar2/pvp/projectile/AbstractArrow.java
+++ b/src/main/java/io/github/togar2/pvp/projectile/AbstractArrow.java
@@ -197,7 +197,7 @@ public abstract class AbstractArrow extends CustomEntityProjectile {
 			return getPiercingLevel() <= 0;
 		} else {
 			Pos position = getPosition();
-			setVelocity(getVelocity().mul(-0.5));
+			setVelocity(getVelocity().mul(-0.5 * 0.2));
 			refreshPosition(position.withYaw(position.yaw() + 170.0f + 20.0f * ThreadLocalRandom.current().nextFloat()));
 			
 			if (getVelocity().lengthSquared() < 1.0E-7D) {


### PR DESCRIPTION
The Minecraft source code multiplies the arrows velocity by 0.2 right after deflecting the arrow, which MinestomPvP did not.