### PR TITLE
Remove fall damage when landing in water

### DIFF
--- a/src/main/java/io/github/togar2/pvp/damage/combat/CombatManager.java
+++ b/src/main/java/io/github/togar2/pvp/damage/combat/CombatManager.java
@@ -47,8 +47,7 @@ public class CombatManager {
 	public @Nullable String getFallLocation(PlayerStateFeature playerStateFeature) {
 		Block lastClimbedBlock = playerStateFeature.getLastClimbedBlock(player);
 		if (lastClimbedBlock == null) {
-			//TODO check for water at feet
-			return null;
+			return player.getInstance().getBlock(player.getPosition().sub(0.0, 1.0, 0.0)) == Block.WATER ? "water" : null;
 		}
 		
 		if (lastClimbedBlock.compare(Block.LADDER) || lastClimbedBlock.compare(Block.ACACIA_TRAPDOOR)

--- a/src/main/java/io/github/togar2/pvp/feature/fall/VanillaFallFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/fall/VanillaFallFeature.java
@@ -161,7 +161,8 @@ public class VanillaFallFeature implements FallFeature, CombatFeature, Registrab
 	@Override
 	public int getFallDamage(LivingEntity entity, double fallDistance) {
 		double safeFallDistance = entity.getAttributeValue(Attribute.GENERIC_SAFE_FALL_DISTANCE);
-		return (int) Math.ceil((fallDistance - safeFallDistance) * entity.getAttributeValue(Attribute.GENERIC_FALL_DAMAGE_MULTIPLIER));
+
+		return entity.getInstance().getBlock(entity.getPosition().sub(0.0, 1.0, 0.0)) != Block.WATER ? (int) Math.ceil((fallDistance - safeFallDistance) * entity.getAttributeValue(Attribute.GENERIC_FALL_DAMAGE_MULTIPLIER)) : 0;
 	}
 	
 	@Override


### PR DESCRIPTION
Changed the getFallLocation function to return the string "water" if the block below the player's feet is of type water.

Changed the getFallDamage function to return 0 as the damage number if the block below the player's feet when they land is water.

Partially closes issue https://github.com/TogAr2/MinestomPvP/issues/31#issue-2283944685