### PR TITLE
Feature Suggestion: Add Prepare Attack Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ The library provides several events:
 - `FinalDamageEvent`: cancellable, called when the final damage calculation (including armor and effects) is completed. This event should be used instead of `EntityDamageEvent`, unless you want to detect how much damage was originally dealt.
 - `FishingBobberRetrieveEvent`: cancellable, called when a player retrieves a fishing bobber.
 - `LegacyKnockbackEvent`: cancellable, called when an entity gets knocked back by another entity using legacy pvp. Same applies as for `EntityKnockbackEvent`. This event can be used to change the knockback settings.
+- `PrepareAttackEvent`: cancellable, called before calculations for a given melee attack are done. Can be used to cancel the attack from happening in known situations where attacks shouldn't occur - ie; in a lobby/waiting phase.
 - `PickupEntityEvent`: cancellable, called when a player picks up an entity (arrow or trident).
 - `PlayerExhaustEvent`: cancellable, called when a players' exhaustion level changes.
 - `PlayerRegenerateEvent`: cancellable, called when a player naturally regenerates health.

--- a/src/main/java/io/github/togar2/pvp/events/PrepareAttackEvent.java
+++ b/src/main/java/io/github/togar2/pvp/events/PrepareAttackEvent.java
@@ -1,0 +1,39 @@
+package io.github.togar2.pvp.events;
+
+import net.minestom.server.entity.Entity;
+import net.minestom.server.event.trait.CancellableEvent;
+import net.minestom.server.event.trait.EntityInstanceEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class PrepareAttackEvent implements EntityInstanceEvent, CancellableEvent {
+
+	private final Entity entity;
+	private final Entity target;
+
+	private boolean cancelled;
+
+	public PrepareAttackEvent(@NotNull Entity entity, @NotNull Entity target) {
+		this.entity = entity;
+		this.target = target;
+	}
+
+	@Override
+	public @NotNull Entity getEntity() {
+		return entity;
+	}
+
+	public @NotNull Entity getTarget() {
+		return target;
+	}
+
+
+	@Override
+	public boolean isCancelled() {
+		return cancelled;
+	}
+
+	@Override
+	public void setCancelled(boolean cancel) {
+		this.cancelled = cancel;
+	}
+}

--- a/src/main/java/io/github/togar2/pvp/feature/attack/VanillaAttackFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/attack/VanillaAttackFeature.java
@@ -85,8 +85,6 @@ public class VanillaAttackFeature implements AttackFeature, RegistrableFeature {
 				&& !player.isDead()
 				&& player.getDistanceSquared(event.getTarget()) < MAX_DISTANCE_SQUARED) {
 				performAttack(player, event.getTarget());
-			} else if (event.getEntity() instanceof LivingEntity living && !living.isDead() && living.getDistanceSquared(event.getTarget()) < MAX_DISTANCE_SQUARED) {
-				performAttack(living, event.getTarget());
 			}
 		});
 	}

--- a/src/main/java/io/github/togar2/pvp/feature/attack/VanillaAttackFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/attack/VanillaAttackFeature.java
@@ -3,6 +3,7 @@ package io.github.togar2.pvp.feature.attack;
 import io.github.togar2.pvp.enchantment.EntityGroup;
 import io.github.togar2.pvp.enums.Tool;
 import io.github.togar2.pvp.events.FinalAttackEvent;
+import io.github.togar2.pvp.events.PrepareAttackEvent;
 import io.github.togar2.pvp.feature.FeatureType;
 import io.github.togar2.pvp.feature.RegistrableFeature;
 import io.github.togar2.pvp.feature.config.DefinedFeature;
@@ -40,30 +41,30 @@ import org.jetbrains.annotations.Nullable;
  */
 public class VanillaAttackFeature implements AttackFeature, RegistrableFeature {
 	public static final DefinedFeature<VanillaAttackFeature> DEFINED = new DefinedFeature<>(
-			FeatureType.ATTACK, VanillaAttackFeature::new,
-			FeatureType.ATTACK_COOLDOWN, FeatureType.EXHAUSTION, FeatureType.ITEM_DAMAGE,
-			FeatureType.ENCHANTMENT, FeatureType.CRITICAL, FeatureType.SWEEPING, FeatureType.KNOCKBACK, FeatureType.VERSION
+		FeatureType.ATTACK, VanillaAttackFeature::new,
+		FeatureType.ATTACK_COOLDOWN, FeatureType.EXHAUSTION, FeatureType.ITEM_DAMAGE,
+		FeatureType.ENCHANTMENT, FeatureType.CRITICAL, FeatureType.SWEEPING, FeatureType.KNOCKBACK, FeatureType.VERSION
 	);
-	
+
 	private static final double MAX_DISTANCE_SQUARED = 36.0;
-	
+
 	private final FeatureConfiguration configuration;
-	
+
 	private AttackCooldownFeature cooldownFeature;
 	private ExhaustionFeature exhaustionFeature;
 	private ItemDamageFeature itemDamageFeature;
-	private EnchantmentFeature enchantmentFeature;;
-	
+	private EnchantmentFeature enchantmentFeature;
+
 	private CriticalFeature criticalFeature;
 	private SweepingFeature sweepingFeature;
 	private KnockbackFeature knockbackFeature;
-	
+
 	private CombatVersion version;
-	
+
 	public VanillaAttackFeature(FeatureConfiguration configuration) {
 		this.configuration = configuration;
 	}
-	
+
 	@Override
 	public void initDependencies() {
 		this.cooldownFeature = configuration.get(FeatureType.ATTACK_COOLDOWN);
@@ -75,187 +76,192 @@ public class VanillaAttackFeature implements AttackFeature, RegistrableFeature {
 		this.knockbackFeature = configuration.get(FeatureType.KNOCKBACK);
 		this.version = configuration.get(FeatureType.VERSION);
 	}
-	
+
 	@Override
 	public void init(EventNode<EntityInstanceEvent> node) {
 		node.addListener(EntityAttackEvent.class, event -> {
 			if (event.getEntity() instanceof Player player
-					&& player.getGameMode() != GameMode.SPECTATOR
-					&& !player.isDead()
-					&& player.getDistanceSquared(event.getTarget()) < MAX_DISTANCE_SQUARED) {
+				&& player.getGameMode() != GameMode.SPECTATOR
+				&& !player.isDead()
+				&& player.getDistanceSquared(event.getTarget()) < MAX_DISTANCE_SQUARED) {
 				performAttack(player, event.getTarget());
+			} else if (event.getEntity() instanceof LivingEntity living && !living.isDead() && living.getDistanceSquared(event.getTarget()) < MAX_DISTANCE_SQUARED) {
+				performAttack(living, event.getTarget());
 			}
 		});
 	}
-	
+
 	@Override
 	public boolean performAttack(LivingEntity attacker, Entity target) {
+		PrepareAttackEvent prepareAttackEvent = new PrepareAttackEvent(attacker, target);
+		EventDispatcher.call(prepareAttackEvent);
+		if (prepareAttackEvent.isCancelled()) return false;
 		AttackValues.Final attack = prepareAttack(attacker, target);
 		if (attack == null) return false; // Event cancelled
-		
+
 		float originalHealth = 0;
 		boolean damageSucceeded = false;
 		if (target instanceof LivingEntity livingTarget) {
 			originalHealth = livingTarget.getHealth();
 			damageSucceeded = livingTarget.damage(new Damage(
-					attacker instanceof Player ? DamageType.PLAYER_ATTACK : DamageType.MOB_ATTACK,
-					attacker, attacker,
-					null, attack.damage()
+				attacker instanceof Player ? DamageType.PLAYER_ATTACK : DamageType.MOB_ATTACK,
+				attacker, attacker,
+				null, attack.damage()
 			));
 		}
-		
+
 		if (!damageSucceeded) {
 			// No damage sound
 			if (attack.sounds() && attack.playSoundsOnFail()) {
 				ViewUtil.viewersAndSelf(attacker).playSound(Sound.sound(
-						SoundEvent.ENTITY_PLAYER_ATTACK_NODAMAGE, Sound.Source.PLAYER,
-						1.0f, 1.0f
+					SoundEvent.ENTITY_PLAYER_ATTACK_NODAMAGE, Sound.Source.PLAYER,
+					1.0f, 1.0f
 				), attacker);
 			}
 			return false;
 		}
-		
+
 		// Target is always living now, because the damage would not have succeeded if it wasn't
 		LivingEntity living = (LivingEntity) target;
-		
+
 		// Knockback and sweeping
 		knockbackFeature.applyAttackKnockback(attacker, living, attack.knockback());
 		if (attack.sweeping()) sweepingFeature.applySweeping(attacker, living, attack.damage());
-		
+
 		if (target instanceof CombatPlayer custom)
 			custom.sendImmediateVelocityUpdate();
-		
+
 		// Play attack sounds
 		if (attack.sounds()) {
 			Audience audience = attacker.getViewersAsAudience();
 			if (attacker instanceof Player player)
 				audience = Audience.audience(audience, player);
-			
+
 			if (attack.sprint()) audience.playSound(Sound.sound(
-					SoundEvent.ENTITY_PLAYER_ATTACK_KNOCKBACK, Sound.Source.PLAYER,
-					1.0f, 1.0f
+				SoundEvent.ENTITY_PLAYER_ATTACK_KNOCKBACK, Sound.Source.PLAYER,
+				1.0f, 1.0f
 			), attacker);
-			
+
 			if (attack.sweeping()) audience.playSound(Sound.sound(
-					SoundEvent.ENTITY_PLAYER_ATTACK_SWEEP, Sound.Source.PLAYER,
-					1.0f, 1.0f
+				SoundEvent.ENTITY_PLAYER_ATTACK_SWEEP, Sound.Source.PLAYER,
+				1.0f, 1.0f
 			), attacker);
-			
+
 			if (attack.critical()) audience.playSound(Sound.sound(
-					SoundEvent.ENTITY_PLAYER_ATTACK_CRIT, Sound.Source.PLAYER,
-					1.0f, 1.0f
+				SoundEvent.ENTITY_PLAYER_ATTACK_CRIT, Sound.Source.PLAYER,
+				1.0f, 1.0f
 			), attacker);
-			
+
 			if (!attack.critical() && !attack.sweeping()) audience.playSound(Sound.sound(
-					attack.strong() ?
-							SoundEvent.ENTITY_PLAYER_ATTACK_STRONG :
-							SoundEvent.ENTITY_PLAYER_ATTACK_WEAK,
-					Sound.Source.PLAYER, 1.0f, 1.0f
+				attack.strong() ?
+					SoundEvent.ENTITY_PLAYER_ATTACK_STRONG :
+					SoundEvent.ENTITY_PLAYER_ATTACK_WEAK,
+				Sound.Source.PLAYER, 1.0f, 1.0f
 			), attacker);
 		}
-		
+
 		// Play attack effects
 		if (attack.critical()) attacker.sendPacketToViewersAndSelf(new EntityAnimationPacket(
-				target.getEntityId(),
-				EntityAnimationPacket.Animation.CRITICAL_EFFECT
+			target.getEntityId(),
+			EntityAnimationPacket.Animation.CRITICAL_EFFECT
 		));
 		if (attack.magical()) attacker.sendPacketToViewersAndSelf(new EntityAnimationPacket(
-				target.getEntityId(),
-				EntityAnimationPacket.Animation.MAGICAL_CRITICAL_EFFECT
+			target.getEntityId(),
+			EntityAnimationPacket.Animation.MAGICAL_CRITICAL_EFFECT
 		));
-		
+
 		// Thorns
 		enchantmentFeature.onUserDamaged(living, attacker);
 		enchantmentFeature.onTargetDamaged(attacker, target);
-		
+
 		// Damage item
 		Tool tool = Tool.fromMaterial(attacker.getItemInMainHand().material());
 		if (tool != null) itemDamageFeature.damageEquipment(attacker, EquipmentSlot.MAIN_HAND,
-					(tool.isSword() || tool == Tool.TRIDENT) ? 1 : 2);
-		
+			(tool.isSword() || tool == Tool.TRIDENT) ? 1 : 2);
+
 		if (attack.fireAspect() > 0)
 			living.setFireTicks(attack.fireAspect() * 4 * ServerFlag.SERVER_TICKS_PER_SECOND);
-		
+
 		// Damage indicator particles
 		float damageDone = originalHealth - living.getHealth();
 		if (damageDone > 2) {
 			int particleCount = (int) (damageDone * 0.5);
 			Pos targetPosition = target.getPosition();
 			target.sendPacketToViewersAndSelf(new ParticlePacket(
-					Particle.DAMAGE_INDICATOR, false,
-					targetPosition.x(), targetPosition.y() + target.getBoundingBox().height() * 0.5, targetPosition.z(),
-					0.1f, 0, 0.1f,
-					0.2F, particleCount
+				Particle.DAMAGE_INDICATOR, false,
+				targetPosition.x(), targetPosition.y() + target.getBoundingBox().height() * 0.5, targetPosition.z(),
+				0.1f, 0, 0.1f,
+				0.2F, particleCount
 			));
 		}
-		
+
 		if (attacker instanceof Player player)
 			exhaustionFeature.addAttackExhaustion(player);
-		
+
 		return true;
 	}
-	
+
 	protected @Nullable AttackValues.Final prepareAttack(LivingEntity attacker, Entity target) {
 		float damage = (float) attacker.getAttributeValue(Attribute.GENERIC_ATTACK_DAMAGE);
 		float magicalDamage = enchantmentFeature.getAttackDamage(
-				attacker.getItemInMainHand(),
-				target instanceof LivingEntity living ? EntityGroup.ofEntity(living) : EntityGroup.DEFAULT
+			attacker.getItemInMainHand(),
+			target instanceof LivingEntity living ? EntityGroup.ofEntity(living) : EntityGroup.DEFAULT
 		);
-		
+
 		double cooldownProgress = 1;
 		if (attacker instanceof Player player) {
 			cooldownProgress = cooldownFeature.getAttackCooldownProgress(player);
 			cooldownFeature.resetCooldownProgress(player);
 		}
-		
+
 		// Apply cooldownProgress to damage
 		damage *= (float) (0.2 + cooldownProgress * cooldownProgress * 0.8);
 		magicalDamage *= (float) cooldownProgress;
-		
+
 		// Calculate attacks
 		boolean strongAttack = cooldownProgress > 0.9;
 		boolean sprintAttack = attacker.isSprinting() && strongAttack;
 		int knockback = enchantmentFeature.getKnockback(attacker);
 		int fireAspect = enchantmentFeature.getFireAspect(attacker);
-		
+
 		// Use features to determine critical and sweeping
 		AttackValues.PreCritical preCritical = new AttackValues.PreCritical(
-				damage, magicalDamage, cooldownProgress,
-				strongAttack, sprintAttack, knockback, fireAspect
+			damage, magicalDamage, cooldownProgress,
+			strongAttack, sprintAttack, knockback, fireAspect
 		);
 		AttackValues.PreSweeping preSweeping = preCritical.withCritical(criticalFeature.shouldCrit(attacker, preCritical));
 		AttackValues.PreSounds preSounds = preSweeping.withSweeping(sweepingFeature.shouldSweep(attacker, preSweeping));
-		
+
 		boolean critical = preSounds.critical();
 		boolean sweeping = preSounds.sweeping();
-		
+
 		boolean sounds = version.modern();
-		
+
 		// Call event which can modify attack values
 		FinalAttackEvent finalAttackEvent = new FinalAttackEvent(
-				attacker, target, sprintAttack, critical, sweeping, damage,
-				magicalDamage, sounds, sounds
+			attacker, target, sprintAttack, critical, sweeping, damage,
+			magicalDamage, sounds, sounds
 		);
 		EventDispatcher.call(finalAttackEvent);
 		if (finalAttackEvent.isCancelled()) return null;
-		
+
 		sprintAttack = finalAttackEvent.isSprint();
 		critical = finalAttackEvent.isCritical();
 		sweeping = finalAttackEvent.isSweeping();
 		damage = finalAttackEvent.getBaseDamage();
 		magicalDamage = finalAttackEvent.getEnchantsExtraDamage();
-		
+
 		// Apply critical damage and knockback
 		if (critical) damage = criticalFeature.applyToDamage(damage);
 		damage += magicalDamage;
-		
+
 		if (sprintAttack) knockback++;
-		
+
 		return new AttackValues.Final(
-				damage, strongAttack, sprintAttack, knockback, critical,
-				magicalDamage > 0, fireAspect, sweeping,
-				finalAttackEvent.hasAttackSounds(),
-				finalAttackEvent.playSoundsOnFail()
+			damage, strongAttack, sprintAttack, knockback, critical,
+			magicalDamage > 0, fireAspect, sweeping,
+			finalAttackEvent.hasAttackSounds(),
+			finalAttackEvent.playSoundsOnFail()
 		);
 	}
 }


### PR DESCRIPTION
Sorry about my IntelliJ linting 🙃 

Feature suggestion to fire an event before details around an attack are calculated, potentially saving time if the dev knows an attack is going to be cancelled