### PR TITLE
Update Minestom and fix projectiles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ java {
 }
 
 dependencies {
-    compileOnly 'net.minestom:minestom-snapshots:a521c4e7cd'
-    testImplementation 'net.minestom:minestom-snapshots:a521c4e7cd'
+    compileOnly 'net.minestom:minestom-snapshots:7ce047b22e'
+    testImplementation 'net.minestom:minestom-snapshots:7ce047b22e'
     //testImplementation 'com.github.TogAr2:MinestomFluids:b237b13a4b'
 }
 

--- a/src/main/java/io/github/togar2/pvp/entity/projectile/CustomEntityProjectile.java
+++ b/src/main/java/io/github/togar2/pvp/entity/projectile/CustomEntityProjectile.java
@@ -48,7 +48,8 @@ public class CustomEntityProjectile extends Entity {
 	}
 	
 	private void setup() {
-		hasCollision = false;
+		collidesWithEntities = false;
+		preventBlockPlacement = false;
 		setAerodynamics(new Aerodynamics(getAerodynamics().gravity(), 0.99, 0.99));
 		if (getEntityMeta() instanceof ProjectileMeta) {
 			((ProjectileMeta) getEntityMeta()).setShooter(shooter);

--- a/src/main/java/io/github/togar2/pvp/utils/ProjectileUtil.java
+++ b/src/main/java/io/github/togar2/pvp/utils/ProjectileUtil.java
@@ -27,6 +27,6 @@ public class ProjectileUtil {
 		Pos positionWithinBorder = CollisionUtils.applyWorldBorder(worldBorder, entityPosition, newPosition);
 		// Originally there was a call to update velocity here, but since projectiles handle it themselves it is not needed
 		return new PhysicsResult(positionWithinBorder, newVelocity, physicsResult.isOnGround(), physicsResult.collisionX(), physicsResult.collisionY(), physicsResult.collisionZ(),
-				physicsResult.originalDelta(), physicsResult.collisionPoints(), physicsResult.collisionShapes(), physicsResult.hasCollision(), physicsResult.res());
+				physicsResult.originalDelta(), physicsResult.collisionPoints(), physicsResult.collisionShapes(), physicsResult.collisionShapePositions(), physicsResult.hasCollision(), physicsResult.res());
 	}
 }

--- a/src/test/java/io/github/togar2/pvp/test/PvpTest.java
+++ b/src/test/java/io/github/togar2/pvp/test/PvpTest.java
@@ -111,7 +111,7 @@ public class PvpTest {
 		MinecraftServer.getCommandManager().register(new Command("shoot") {{
 			setDefaultExecutor((sender, args) -> {
 				if (sender instanceof Player player) {
-					PlayerProjectile projectile = new PlayerProjectile(player, EntityType.ARROW);
+					EntityProjectile projectile = new EntityProjectile(player, EntityType.ARROW);
 					projectile.setInstance(player.getInstance(), player.getPosition().add(0, player.getEyeHeight(), 0));
 					projectile.shoot(player.getPosition().add(player.getPosition().direction()).add(0, 2, 0), 1, 0);
 					player.sendMessage("oui");


### PR DESCRIPTION
I was using MinestomPvP with the latest commit of Minestom and noticed that projectiles were causing exceptions and did not appear in the world at all. The changes I've made should make MinestomPvP compatible with recent Minestom API changes to projectiles and update MinestomPvP to depend on the latest version of Minestom.

I did some testing and this seems to have resolved the issue.