### PR TITLE
Projectiles erroring in unloaded chunks

### DIFF
--- a/src/main/java/io/github/togar2/pvp/entity/projectile/CustomEntityProjectile.java
+++ b/src/main/java/io/github/togar2/pvp/entity/projectile/CustomEntityProjectile.java
@@ -214,12 +214,12 @@ public class CustomEntityProjectile extends Entity {
 		if (!isStuck()) {
 			Vec diff = velocity.div(ServerFlag.SERVER_TICKS_PER_SECOND);
 			// Prevent entity infinitely in the void
-			if(instance.isInVoid(position)) {
+			if (instance.isInVoid(position)) {
 				scheduler().scheduleNextProcess(this::remove);
 				return;
 			}
-            ChunkCache blockGetter = new ChunkCache(instance, instance.getChunkAt(position), Block.AIR);
-
+			
+            ChunkCache blockGetter = new ChunkCache(instance, currentChunk, Block.AIR);
 			PhysicsResult physicsResult = ProjectileUtil.simulateMovement(position, diff, POINT_BOX,
 					instance.getWorldBorder(), blockGetter, hasPhysics, previousPhysicsResult, true);
 			this.previousPhysicsResult = physicsResult;


### PR DESCRIPTION
When a projectile is shot into the void or just generally into unloaded chunks, it will cause errors due to the implementation of collisions, this adds a ChunkCache on top of the check that returns AIR if the chunk is unloaded.

There is also code to remove the projectile when it travels into the void as specified by the `isInVoid` function.