### PR TITLE
Support 1.21.11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-minestom = "2025.10.31-1.21.10"
+minestom = "2025.12.20c-1.21.11"
 fastutil = "8.5.12"
 
 [libraries]

--- a/src/main/java/io/github/togar2/pvp/feature/explosion/VanillaExplosionSupplier.java
+++ b/src/main/java/io/github/togar2/pvp/feature/explosion/VanillaExplosionSupplier.java
@@ -27,6 +27,8 @@ import net.minestom.server.network.packet.server.play.ExplosionPacket;
 import net.minestom.server.particle.Particle;
 import net.minestom.server.sound.SoundEvent;
 
+import net.minestom.server.utils.WeightedList;
+import net.minestom.server.utils.WeightedList.Entry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,9 +40,9 @@ public final class VanillaExplosionSupplier implements ExplosionSupplier {
 
 	private final EnchantmentFeature enchantmentFeature;
 
-    private final List<ExplosionPacket.BlockParticleInfo> PARTICLES = List.of(
-            new ExplosionPacket.BlockParticleInfo(Particle.POOF, 0.5f, 1.0f, 1),
-            new ExplosionPacket.BlockParticleInfo(Particle.SMOKE, 1.0f, 1.0f, 1)
+    private final WeightedList<ExplosionPacket.BlockParticleInfo> PARTICLES = WeightedList.of(
+            new Entry<>(new ExplosionPacket.BlockParticleInfo(Particle.POOF, 0.5f, 1.0f), 1),
+            new Entry<>(new ExplosionPacket.BlockParticleInfo(Particle.SMOKE, 1.0f, 1.0f), 1)
     );
 
 	VanillaExplosionSupplier(ExplosionFeature feature, EnchantmentFeature enchantmentFeature) {

--- a/src/main/java/io/github/togar2/pvp/feature/explosion/VanillaExplosiveFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/explosion/VanillaExplosiveFeature.java
@@ -8,10 +8,12 @@ import io.github.togar2.pvp.feature.FeatureType;
 import io.github.togar2.pvp.feature.RegistrableFeature;
 import io.github.togar2.pvp.feature.config.DefinedFeature;
 import io.github.togar2.pvp.feature.config.FeatureConfiguration;
+import io.github.togar2.pvp.feature.explosion.ExplosionFeature.IgnitionCause.ByPlayer;
 import io.github.togar2.pvp.feature.item.ItemDamageFeature;
 import io.github.togar2.pvp.utils.ViewUtil;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.sound.Sound.Source;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.collision.BoundingBox;
 import net.minestom.server.coordinate.Point;
@@ -29,7 +31,13 @@ import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
+import net.minestom.server.registry.DynamicRegistry;
 import net.minestom.server.sound.SoundEvent;
+import net.minestom.server.world.DimensionType;
+import net.minestom.server.world.attribute.EnvironmentAttribute;
+import net.minestom.server.world.attribute.EnvironmentAttribute.Modifier;
+import net.minestom.server.world.attribute.EnvironmentAttributeMap;
+import net.minestom.server.world.biome.Biome;
 
 /**
  * Vanilla implementation of {@link ExplosiveFeature}
@@ -39,22 +47,22 @@ public class VanillaExplosiveFeature implements ExplosiveFeature, RegistrableFea
 			FeatureType.EXPLOSIVE, VanillaExplosiveFeature::new,
 			FeatureType.EXPLOSION, FeatureType.ITEM_DAMAGE
 	);
-	
+
 	private final FeatureConfiguration configuration;
-	
+
 	private ExplosionFeature explosionFeature;
 	private ItemDamageFeature itemDamageFeature;
-	
+
 	public VanillaExplosiveFeature(FeatureConfiguration configuration) {
 		this.configuration = configuration;
 	}
-	
+
 	@Override
 	public void initDependencies() {
 		this.explosionFeature = configuration.get(FeatureType.EXPLOSION);
 		this.itemDamageFeature = configuration.get(FeatureType.ITEM_DAMAGE);
 	}
-	
+
 	@Override
 	public void init(EventNode<EntityInstanceEvent> node) {
 		node.addListener(PlayerUseItemOnBlockEvent.class, event -> {
@@ -62,14 +70,14 @@ public class VanillaExplosiveFeature implements ExplosiveFeature, RegistrableFea
 			Instance instance = event.getInstance();
 			Point position = event.getPosition();
 			Player player = event.getPlayer();
-			
+
 			if (stack.material() != Material.FLINT_AND_STEEL && stack.material() != Material.FIRE_CHARGE) return;
 			Block block = instance.getBlock(position);
 			if (!block.compare(Block.TNT)) return;
-			
-			explosionFeature.primeExplosive(instance, position, new ExplosionFeature.IgnitionCause.ByPlayer(player), 80);
+
+			explosionFeature.primeExplosive(instance, position, new ByPlayer(player), 80);
 			instance.setBlock(position, Block.AIR);
-			
+
 			if (player.getGameMode() != GameMode.CREATIVE) {
 				if (stack.material() == Material.FLINT_AND_STEEL) {
 					itemDamageFeature.damageEquipment(player, event.getHand() == PlayerHand.MAIN
@@ -79,71 +87,91 @@ public class VanillaExplosiveFeature implements ExplosiveFeature, RegistrableFea
 				}
 			}
 		});
-		
+
 		node.addListener(PlayerUseItemOnBlockEvent.class, event -> {
 			if (event.getItemStack().material() != Material.END_CRYSTAL) return;
 			Instance instance = event.getInstance();
 			Block block = instance.getBlock(event.getPosition());
 			if (!block.compare(Block.OBSIDIAN) && !block.compare(Block.BEDROCK)) return;
-			
+
 			Point above = event.getPosition().add(0, 1, 0);
 			if (!instance.getBlock(above).isAir()) return;
-			
+
 			BoundingBox checkIntersect = new BoundingBox(1, 2, 1);
 			for (Entity entity : instance.getNearbyEntities(above, 3)) {
 				if (entity.getBoundingBox().intersectBox(above.sub(entity.getPosition()), checkIntersect)) return;
 			}
-			
+
 			Point spawnPosition = above.add(0.5, 0, 0.5);
 			var crystalPlaceEvent = new CrystalPlaceEvent(event.getPlayer(), spawnPosition);
-			
+
 			EventDispatcher.callCancellable(crystalPlaceEvent, () -> {
 				CrystalEntity entity = new CrystalEntity();
 				entity.setInstance(instance, crystalPlaceEvent.getSpawnPosition());
-				
+
 				if (event.getPlayer().getGameMode() != GameMode.CREATIVE)
 					event.getPlayer().setItemInHand(event.getHand(), event.getItemStack().consume(1));
 			});
 		});
-		
+
 		node.addListener(PlayerBlockInteractEvent.class, event -> {
 			Instance instance = event.getInstance();
 			Block block = instance.getBlock(event.getBlockPosition());
 			Player player = event.getPlayer();
 			if (!block.compare(Block.RESPAWN_ANCHOR)) return;
-			
+
 			// Exit if offhand has glowstone but current hand is main, to prevent exploding when it should be charged instead
 			if (event.getHand() == PlayerHand.MAIN
 					&& player.getItemInMainHand().material() != Material.GLOWSTONE
 					&& player.getItemInOffHand().material() == Material.GLOWSTONE)
 				return;
-			
+
 			ItemStack stack = player.getItemInHand(event.getHand());
 			int charges = Integer.parseInt(block.getProperty("charges"));
 			if (stack.material() == Material.GLOWSTONE && charges < 4) {
 				var anchorChargeEvent = new AnchorChargeEvent(player, event.getBlockPosition());
 				EventDispatcher.call(anchorChargeEvent);
-				
+
 				if (!anchorChargeEvent.isCancelled()) {
 					instance.setBlock(event.getBlockPosition(),
 							block.withProperty("charges", String.valueOf(charges + 1)));
 					ViewUtil.packetGroup(player).playSound(Sound.sound(
-							SoundEvent.BLOCK_RESPAWN_ANCHOR_CHARGE, Sound.Source.BLOCK,
+							SoundEvent.BLOCK_RESPAWN_ANCHOR_CHARGE, Source.BLOCK,
 							1.0f, 1.0f
 					), event.getBlockPosition().add(0.5, 0.5, 0.5));
-					
+
 					if (player.getGameMode() != GameMode.CREATIVE)
 						player.setItemInHand(event.getHand(), player.getItemInHand(event.getHand()).consume(1));
-					
+
 					event.setBlockingItemUse(true);
 					return;
 				}
 			}
-			
+
 			if (charges == 0) return;
-			
-			if (instance.getExplosionSupplier() != null
-					&& MinecraftServer.getDimensionTypeRegistry().get(instance.getDimensionType()).respawnAnchorWorks()) {
+
+            EnvironmentAttributeMap dim = MinecraftServer.getDimensionTypeRegistry().get(instance.getDimensionType()).attributes();
+
+			boolean worksInDimension = (Boolean) dim.entries().get(EnvironmentAttribute.RESPAWN_ANCHOR_WORKS).argument();
+
+			Biome biome = MinecraftServer.getBiomeRegistry().get(instance.getChunkAt(event.getBlockPosition())
+                .getBiome(event.getBlockPosition()));
+
+			boolean respawnAnchorWorks;
+			 if (biome.attributes().entries().containsKey(EnvironmentAttribute.RESPAWN_ANCHOR_WORKS)) {
+                 //noinspection unchecked
+				 respawnAnchorWorks = ((Modifier<Boolean, Boolean>) biome.attributes().entries()
+                     .get(EnvironmentAttribute.RESPAWN_ANCHOR_WORKS).modifier())
+                     .modify(worksInDimension, (Boolean) biome.attributes().entries()
+                         .get(EnvironmentAttribute.RESPAWN_ANCHOR_WORKS).argument());
+
+			 } else {
+                 respawnAnchorWorks = worksInDimension;
+             }
+
+
+
+			if (instance.getExplosionSupplier() != null && !respawnAnchorWorks) {
 				var anchorExplodeEvent = new AnchorExplodeEvent(player, event.getBlockPosition());
 				EventDispatcher.callCancellable(anchorExplodeEvent, () -> {
 					instance.setBlock(event.getBlockPosition(), Block.AIR);
@@ -159,7 +187,7 @@ public class VanillaExplosiveFeature implements ExplosiveFeature, RegistrableFea
 					);
 				});
 			}
-			
+
 			event.setBlockingItemUse(true);
 		});
 	}

--- a/src/main/java/io/github/togar2/pvp/feature/explosion/VanillaExplosiveFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/explosion/VanillaExplosiveFeature.java
@@ -169,8 +169,6 @@ public class VanillaExplosiveFeature implements ExplosiveFeature, RegistrableFea
                  respawnAnchorWorks = worksInDimension;
              }
 
-
-
 			if (instance.getExplosionSupplier() != null && !respawnAnchorWorks) {
 				var anchorExplodeEvent = new AnchorExplodeEvent(player, event.getBlockPosition());
 				EventDispatcher.callCancellable(anchorExplodeEvent, () -> {

--- a/src/test/java/io/github/togar2/pvp/test/PvpTest.java
+++ b/src/test/java/io/github/togar2/pvp/test/PvpTest.java
@@ -32,6 +32,7 @@ import net.minestom.server.potion.PotionEffect;
 import net.minestom.server.registry.RegistryKey;
 import net.minestom.server.utils.time.TimeUnit;
 import net.minestom.server.world.DimensionType;
+import net.minestom.server.world.attribute.EnvironmentAttribute;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -44,7 +45,10 @@ public class PvpTest {
 		//MinestomFluids.init();
 		//VelocityProxy.enable("tj7MulOtnIDe");
 		
-		DimensionType fullbright = DimensionType.builder().ambientLight(1.0f).respawnAnchorWorks(true).build();
+		DimensionType fullbright = DimensionType.builder()
+			.ambientLight(1.0f)
+			.setAttribute(EnvironmentAttribute.RESPAWN_ANCHOR_WORKS, true) // respawn anchors won't explode
+			.build();
 		RegistryKey<DimensionType> fullbrightKey =
 				MinecraftServer.getDimensionTypeRegistry().register(Key.key("idk"), fullbright);
 		


### PR DESCRIPTION
This PR adds support for 1.21.11, now that Minestom does. It incorporates support for the new Environment Attributes introduced in 1.21.11. 

Edit 1: This is PR does bring a breaking change to bring parity with the vanilla server: Changing the environment attribute `gameplay/respawn_anchor_works` to `true` means the respawn anchors function as a respawn point. Setting it to `false` makes them explode as detailed here: https://minecraft.wiki/w/Environment_attribute#List_of_attributes