### PR TITLE
Fall damage improvements

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-minestom = "2026.01.08-1.21.11"
+minestom = "2025.12.20c-1.21.11"
 fastutil = "8.5.12"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-minestom = "2025.12.20c-1.21.11"
+minestom = "2026.01.08-1.21.11"
 fastutil = "8.5.12"
 
 [libraries]

--- a/src/main/java/io/github/togar2/pvp/enums/ArmorMaterial.java
+++ b/src/main/java/io/github/togar2/pvp/enums/ArmorMaterial.java
@@ -3,6 +3,7 @@ package io.github.togar2.pvp.enums;
 import io.github.togar2.pvp.utils.CombatVersion;
 import io.github.togar2.pvp.utils.ModifierId;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
 import net.minestom.server.component.DataComponents;
 import net.minestom.server.entity.EquipmentSlot;
 import net.minestom.server.entity.LivingEntity;
@@ -94,6 +95,12 @@ public enum ArmorMaterial {
 					entity.getAttribute(Attribute.KNOCKBACK_RESISTANCE).addModifier(new AttributeModifier(modifierId, newMaterial.getKnockbackResistance(), AttributeOperation.ADD_VALUE));
 				}
 			}
+		}
+
+		if (version.modern()) {
+			ArmorMaterial armorMaterial = fromMaterial(newStack.material());
+			if (armorMaterial == null) return;
+			entity.getInstance().playSound(Sound.sound(armorMaterial.equipSound, Sound.Source.PLAYER, 1f, 1f));
 		}
 	}
 	

--- a/src/main/java/io/github/togar2/pvp/enums/ArmorMaterial.java
+++ b/src/main/java/io/github/togar2/pvp/enums/ArmorMaterial.java
@@ -3,7 +3,6 @@ package io.github.togar2.pvp.enums;
 import io.github.togar2.pvp.utils.CombatVersion;
 import io.github.togar2.pvp.utils.ModifierId;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.sound.Sound;
 import net.minestom.server.component.DataComponents;
 import net.minestom.server.entity.EquipmentSlot;
 import net.minestom.server.entity.LivingEntity;
@@ -26,14 +25,14 @@ public enum ArmorMaterial {
 	DIAMOND(new int[]{3, 6, 8, 3}, new int[]{3, 8, 6, 3}, SoundEvent.ITEM_ARMOR_EQUIP_DIAMOND, 2.0F, 0.0F, Material.DIAMOND_BOOTS, Material.DIAMOND_LEGGINGS, Material.DIAMOND_CHESTPLATE, Material.DIAMOND_HELMET),
 	TURTLE(new int[]{2, 5, 6, 2}, new int[]{2, 6, 5, 2}, SoundEvent.ITEM_ARMOR_EQUIP_TURTLE, 0.0F, 0.0F, Material.TURTLE_HELMET),
 	NETHERITE(new int[]{3, 6, 8, 3}, new int[]{3, 8, 6, 3}, SoundEvent.ITEM_ARMOR_EQUIP_NETHERITE, 3.0F, 0.1F, Material.NETHERITE_BOOTS, Material.NETHERITE_LEGGINGS, Material.NETHERITE_CHESTPLATE, Material.NETHERITE_HELMET);
-	
+
 	private final int[] protectionAmounts;
 	private final int[] legacyProtectionAmounts;
 	private final SoundEvent equipSound;
 	private final float toughness;
 	private final float knockbackResistance;
 	private final Material[] items;
-	
+
 	ArmorMaterial(int[] protectionAmounts, int[] legacyProtectionAmounts, SoundEvent equipSound, float toughness, float knockbackResistance, Material... items) {
 		this.protectionAmounts = protectionAmounts;
 		this.legacyProtectionAmounts = legacyProtectionAmounts;
@@ -42,7 +41,7 @@ public enum ArmorMaterial {
 		this.knockbackResistance = knockbackResistance;
 		this.items = items;
 	}
-	
+
 	public int getProtectionAmount(EquipmentSlot slot, CombatVersion version) {
 		int id;
 		switch (slot) {
@@ -54,29 +53,29 @@ public enum ArmorMaterial {
 				return 0;
 			}
 		}
-		
+
 		return version.legacy() ? this.legacyProtectionAmounts[id] : this.protectionAmounts[id];
 	}
-	
+
 	public SoundEvent getEquipSound() {
 		return this.equipSound;
 	}
-	
+
 	public float getToughness() {
 		return this.toughness;
 	}
-	
+
 	public float getKnockbackResistance() {
 		return this.knockbackResistance;
 	}
-	
+
 	public static void updateEquipmentAttributes(LivingEntity entity, ItemStack oldStack, ItemStack newStack,
-	                                             EquipmentSlot slot, CombatVersion version) {
+												 EquipmentSlot slot, CombatVersion version) {
 		ArmorMaterial oldMaterial = fromMaterial(oldStack.material());
 		ArmorMaterial newMaterial = fromMaterial(newStack.material());
-		
+
 		Key modifierId = getModifierId(slot);
-		
+
 		// Remove attributes from previous armor
 		if (oldMaterial != null && hasDefaultAttributes(oldStack)) {
 			if (slot == getRequiredSlot(oldStack.material())) {
@@ -85,7 +84,7 @@ public enum ArmorMaterial {
 				entity.getAttribute(Attribute.KNOCKBACK_RESISTANCE).removeModifier(modifierId);
 			}
 		}
-		
+
 		// Add attributes from new armor
 		if (newMaterial != null && hasDefaultAttributes(newStack)) {
 			if (slot == getRequiredSlot(newStack.material())) {
@@ -96,35 +95,29 @@ public enum ArmorMaterial {
 				}
 			}
 		}
-
-		if (version.modern()) {
-			ArmorMaterial armorMaterial = fromMaterial(newStack.material());
-			if (armorMaterial == null) return;
-			entity.getInstance().playSound(Sound.sound(armorMaterial.equipSound, Sound.Source.PLAYER, 1f, 1f));
-		}
 	}
-	
+
 	private static boolean hasDefaultAttributes(ItemStack stack) {
 		// When modifiers tag is not empty, default modifiers are not
 		return !stack.has(DataComponents.ATTRIBUTE_MODIFIERS)
-				|| Objects.requireNonNull(stack.get(DataComponents.ATTRIBUTE_MODIFIERS)).modifiers().isEmpty();
+			|| Objects.requireNonNull(stack.get(DataComponents.ATTRIBUTE_MODIFIERS)).modifiers().isEmpty();
 	}
-	
+
 	public static EquipmentSlot getRequiredSlot(Material material) {
 		EquipmentSlot slot = material.registry().equipmentSlot();
 		return slot == null ? EquipmentSlot.HELMET : slot;
 	}
-	
+
 	private static final Map<Material, ArmorMaterial> MATERIAL_TO_ARMOR_MATERIAL = new HashMap<>();
-	
+
 	public static ArmorMaterial fromMaterial(Material material) {
 		return MATERIAL_TO_ARMOR_MATERIAL.get(material);
 	}
-	
+
 	public static Key getModifierId(EquipmentSlot slot) {
 		return ModifierId.ARMOR_MODIFIERS[slot.ordinal() - 2];
 	}
-	
+
 	static {
 		for (ArmorMaterial armorMaterial : values()) {
 			for (Material material : armorMaterial.items) {

--- a/src/main/java/io/github/togar2/pvp/feature/fall/FallFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/fall/FallFeature.java
@@ -20,7 +20,7 @@ public interface FallFeature extends CombatFeature {
 		}
 		
 		@Override
-		public void resetFallDistance(LivingEntity entity) {}
+		public void resetFallDistance(LivingEntity entity, double newPeakY) {}
 		
 		@Override
 		public void setExtraFallParticles(LivingEntity entity, boolean extraFallParticles) {}
@@ -29,8 +29,12 @@ public interface FallFeature extends CombatFeature {
 	int getFallDamage(LivingEntity entity, double fallDistance);
 	
 	double getFallDistance(LivingEntity entity);
-	
-	void resetFallDistance(LivingEntity entity);
+
+	default void resetFallDistance(LivingEntity entity) {
+		resetFallDistance(entity, entity.getPosition().y());
+	}
+
+	void resetFallDistance(LivingEntity entity, double newPeakY);
 	
 	void setExtraFallParticles(LivingEntity entity, boolean extraFallParticles);
 }

--- a/src/main/java/io/github/togar2/pvp/feature/fall/VanillaFallFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/fall/VanillaFallFeature.java
@@ -74,7 +74,6 @@ public class VanillaFallFeature implements FallFeature, RegistrableFeature {
 		node.addListener(PlayerMoveEvent.class, event -> {
 			Player player = event.getPlayer();
 			if (playerStateFeature.isClimbing(player)) resetFallDistance(player);
-			//System.out.println(event.isOnGround());
 			handleFallDamage(
 					player, player.getPosition(),
 					event.getNewPosition(), event.isOnGround()
@@ -130,7 +129,6 @@ public class VanillaFallFeature implements FallFeature, RegistrableFeature {
 		}
 
 		double safeFallDistance = entity.getAttributeValue(Attribute.SAFE_FALL_DISTANCE);
-		System.out.println("fd: " + fallDistance + " | sfd: " + safeFallDistance);
 		if (fallDistance > safeFallDistance) {
 			if (!block.isAir()) {
 				double damageDistance = Math.ceil(fallDistance - safeFallDistance);
@@ -170,7 +168,7 @@ public class VanillaFallFeature implements FallFeature, RegistrableFeature {
 	@Override
 	public int getFallDamage(LivingEntity entity, double fallDistance) {
 		double safeFallDistance = entity.getAttributeValue(Attribute.SAFE_FALL_DISTANCE);
-		return (int) Math.max(0, Math.round((fallDistance - safeFallDistance) * entity.getAttributeValue(Attribute.FALL_DAMAGE_MULTIPLIER)));
+		return (int) Math.round((fallDistance - safeFallDistance) * entity.getAttributeValue(Attribute.FALL_DAMAGE_MULTIPLIER));
 	}
 
 	@Override

--- a/src/test/java/io/github/togar2/pvp/test/commands/Commands.java
+++ b/src/test/java/io/github/togar2/pvp/test/commands/Commands.java
@@ -10,5 +10,6 @@ public class Commands {
 		commandManager.register(new GameModeCommand());
 		commandManager.register(new DamageCommand());
 		commandManager.register(new ClearCommand());
+		commandManager.register(new HealCommand());
 	}
 }

--- a/src/test/java/io/github/togar2/pvp/test/commands/HealCommand.java
+++ b/src/test/java/io/github/togar2/pvp/test/commands/HealCommand.java
@@ -1,0 +1,19 @@
+package io.github.togar2.pvp.test.commands;
+
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.command.builder.condition.Conditions;
+import net.minestom.server.entity.Player;
+import net.minestom.server.entity.attribute.Attribute;
+
+public class HealCommand extends Command {
+
+    public HealCommand() {
+        super("heal");
+        setCondition(Conditions::playerOnly);
+        setDefaultExecutor((sender, context) -> {
+            Player p = (Player) sender;
+            p.setHealth((float) p.getAttributeValue(Attribute.MAX_HEALTH));
+        });
+    }
+
+}


### PR DESCRIPTION
This PR changes the formula to use round instead of ceil when calculating fall damage. When testing floor it produced false results. Additionally, peak y of falling is now taken into account which fixes #77 .

Video below is showcasing the parity with vanilla fall damage (vanilla on left, minestom pvp on the right)

https://youtu.be/8v6K3-Liiys