### PR TITLE
Replace PlayerPreEatEvent by PlayerBeginItemUseEvent

### DIFF
--- a/src/main/java/io/github/togar2/pvp/feature/food/VanillaFoodFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/food/VanillaFoodFeature.java
@@ -15,7 +15,7 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.entity.PlayerHand;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.event.item.PlayerFinishItemUseEvent;
-import net.minestom.server.event.player.PlayerPreEatEvent;
+import net.minestom.server.event.item.PlayerBeginItemUseEvent;
 import net.minestom.server.event.player.PlayerTickEvent;
 import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.item.ItemStack;
@@ -64,7 +64,7 @@ public class VanillaFoodFeature implements FoodFeature, RegistrableFeature {
 	
 	@Override
 	public void init(EventNode<EntityInstanceEvent> node) {
-		node.addListener(PlayerPreEatEvent.class, event -> {
+		node.addListener(PlayerBeginItemUseEvent.class, event -> {
 			if (!event.getItemStack().has(DataComponents.CONSUMABLE))
 				return;
 			@Nullable Food foodComponent = event.getItemStack().get(DataComponents.FOOD);
@@ -79,7 +79,7 @@ public class VanillaFoodFeature implements FoodFeature, RegistrableFeature {
 				return;
 			}
 			
-			if (consumableComponent != null) event.setEatingTime(consumableComponent.consumeTicks());
+			if (consumableComponent != null) event.setItemUseDuration(consumableComponent.consumeTicks());
 		});
 		
 		node.addListener(PlayerFinishItemUseEvent.class, event -> {


### PR DESCRIPTION
PlayerPreEatEvent was disabled in Minestom and has been removed recently. This change allows running MinestomPvP on later Minestom versions (I tested on 2026.03.03-1.21.11).