### PR TITLE
Set the potion duration of tipped arrow custom effects to 1/8 of the duration

### DIFF
--- a/src/main/java/io/github/togar2/pvp/feature/effect/VanillaEffectFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/effect/VanillaEffectFeature.java
@@ -254,8 +254,9 @@ public class VanillaEffectFeature implements EffectFeature, RegistrableFeature {
 						combatPotionEffect.applyInstantEffect(arrow, null,
 								entity, potion.amplifier(), 1.0, exhaustionFeature, foodFeature);
 					} else {
+                        int duration = Math.max(potion.duration() / 8, 1);
 						entity.addEffect(new Potion(potion.effect(), potion.amplifier(),
-								potion.duration(), potion.flags()));
+								duration, potion.flags()));
 					}
 				});
 	}


### PR DESCRIPTION
Closes #76 