### PR TITLE
Refactored VanillaItemCooldownFeature

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -49,7 +49,6 @@ Currently, most vanilla PvP mechanics are supported.
 
 ## Plans
 
-- Lingering potions
 - Fireworks (for crossbows)
 - Support for (some) water mechanics (e.g. slowing projectiles down)
 - 1.21 features (the library is already 1.21 compatible, just doesn't support its combat features)

--- a/src/main/java/io/github/togar2/pvp/feature/block/VanillaBlockFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/block/VanillaBlockFeature.java
@@ -144,7 +144,7 @@ public class VanillaBlockFeature implements BlockFeature {
 	}
 	
 	protected void disableShield(Player player) {
-		itemCooldownFeature.setCooldown(player, Material.SHIELD, 100);
+		itemCooldownFeature.setCooldown(player, Material.SHIELD.name(), 100);
 		
 		// Shield disable status
 		player.triggerStatus((byte) 30);

--- a/src/main/java/io/github/togar2/pvp/feature/cooldown/ItemCooldownFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/cooldown/ItemCooldownFeature.java
@@ -2,7 +2,7 @@ package io.github.togar2.pvp.feature.cooldown;
 
 import io.github.togar2.pvp.feature.CombatFeature;
 import net.minestom.server.entity.Player;
-import net.minestom.server.item.Material;
+import net.minestom.server.item.ItemStack;
 
 /**
  * Combat feature to manage a players item cooldown animation.
@@ -10,15 +10,29 @@ import net.minestom.server.item.Material;
 public interface ItemCooldownFeature extends CombatFeature {
 	ItemCooldownFeature NO_OP = new ItemCooldownFeature() {
 		@Override
-		public boolean hasCooldown(Player player, Material material) {
+		public boolean hasCooldown(Player player, String cooldownGroup) {
 			return false;
 		}
-		
-		@Override
-		public void setCooldown(Player player, Material material, int ticks) {}
-	};
+
+        @Override
+        public boolean hasCooldown(Player player, ItemStack itemStack) {
+            return false;
+        }
+
+        @Override
+		public void setCooldown(Player player, String cooldownGroup, int ticks) {}
+
+        @Override
+        public void setCooldown(Player player, ItemStack itemStack, int ticks) {
+
+        }
+    };
 	
-	boolean hasCooldown(Player player, Material material);
+	boolean hasCooldown(Player player, String cooldownGroup);
+
+    boolean hasCooldown(Player player, ItemStack itemStack);
 	
-	void setCooldown(Player player, Material material, int ticks);
+	void setCooldown(Player player, String cooldownGroup, int ticks);
+
+    void setCooldown(Player player, ItemStack itemStack, int ticks);
 }

--- a/src/main/java/io/github/togar2/pvp/feature/cooldown/ItemCooldownFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/cooldown/ItemCooldownFeature.java
@@ -23,23 +23,59 @@ public interface ItemCooldownFeature extends CombatFeature {
 		public void setCooldown(Player player, String cooldownGroup, int ticks) {}
 
         @Override
-        public void setCooldown(Player player, ItemStack itemStack, int ticks) {
-
-        }
+        public void setCooldown(Player player, ItemStack itemStack, int ticks) {}
 
         @Override
-        public void setCooldown(Player player, ItemStack itemStack) {
-
-        }
+        public void setCooldown(Player player, ItemStack itemStack) {}
     };
-	
+
+    /**
+     *                      Checks if a player has a cooldown group on cooldown
+     * @param player        The player to check
+     * @param cooldownGroup The cooldown group, usually from the item's {@link net.minestom.server.item.component.UseCooldown}
+     *                      component or the item's material
+     * @return              {@code true} if player has cooldown for item's cooldown group, otherwise {@code false}
+     */
 	boolean hasCooldown(Player player, String cooldownGroup);
 
+    /**
+     *                      Checks if a player has an item on cooldown
+     * @param player        The player to check
+     * @param itemStack     The item, from which the cooldown group is fetched from the item's
+     *                      {@link net.minestom.server.item.component.UseCooldown}, otherwise uses the item's
+     *                      material if component is null
+     * @return              {@code true} if player has cooldown for item's cooldown group, otherwise {@code false}
+     */
     boolean hasCooldown(Player player, ItemStack itemStack);
-	
+
+    /**
+     *                      Sets the cooldown of a cooldown group for a player
+     * @param player        The player to target
+     * @param cooldownGroup The cooldown group, usually from the item's {@link net.minestom.server.item.component.UseCooldown}
+     *                      component or the item's material
+     * @param ticks         The amount of ticks to set the cooldown for
+     */
 	void setCooldown(Player player, String cooldownGroup, int ticks);
 
+    /**
+     *                      Sets the cooldown of an item for a player
+     * @param player        The player to target
+     * @param itemStack     The item, from which the cooldown group is fetched from the item's
+     *                      {@link net.minestom.server.item.component.UseCooldown}, otherwise uses the item's material
+     *                      if component is null
+     * @param ticks         The amount of ticks to set the cooldown for
+     */
     void setCooldown(Player player, ItemStack itemStack, int ticks);
 
+    /**
+     *                      Sets the cooldown of an item for a player
+     *                      This method calculates the ticks from the item's {@link net.minestom.server.item.component.UseCooldown}
+     *                      component, otherwise defaults to 0 ticks (no cooldown) if component is null
+     *
+     * @param player        The player to target
+     * @param itemStack     The item, from which the cooldown group is fetched from the item's
+     *                      {@link net.minestom.server.item.component.UseCooldown}, otherwise uses the item's material
+     *                      if component is null
+     */
     void setCooldown(Player player, ItemStack itemStack);
 }

--- a/src/main/java/io/github/togar2/pvp/feature/cooldown/ItemCooldownFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/cooldown/ItemCooldownFeature.java
@@ -26,6 +26,11 @@ public interface ItemCooldownFeature extends CombatFeature {
         public void setCooldown(Player player, ItemStack itemStack, int ticks) {
 
         }
+
+        @Override
+        public void setCooldown(Player player, ItemStack itemStack) {
+
+        }
     };
 	
 	boolean hasCooldown(Player player, String cooldownGroup);
@@ -35,4 +40,6 @@ public interface ItemCooldownFeature extends CombatFeature {
 	void setCooldown(Player player, String cooldownGroup, int ticks);
 
     void setCooldown(Player player, ItemStack itemStack, int ticks);
+
+    void setCooldown(Player player, ItemStack itemStack);
 }

--- a/src/main/java/io/github/togar2/pvp/feature/cooldown/VanillaItemCooldownFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/cooldown/VanillaItemCooldownFeature.java
@@ -103,6 +103,13 @@ public class VanillaItemCooldownFeature implements ItemCooldownFeature, Registra
         setCooldown(player, cooldownGroup, ticks);
     }
 
+    @Override
+    public void setCooldown(Player player, ItemStack itemStack) {
+        UseCooldown useCooldown = itemStack.get(DataComponents.USE_COOLDOWN);
+        int ticks = useCooldown != null ? (int) useCooldown.seconds() * 20 : 0;
+        setCooldown(player, itemStack, ticks);
+    }
+
     protected void sendCooldownPacket(Player player, String cooldownGroup, int ticks) {
 		player.getPlayerConnection().sendPacket(new SetCooldownPacket(cooldownGroup, ticks));
 	}

--- a/src/main/java/io/github/togar2/pvp/feature/cooldown/VanillaItemCooldownFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/cooldown/VanillaItemCooldownFeature.java
@@ -4,12 +4,14 @@ import io.github.togar2.pvp.feature.FeatureType;
 import io.github.togar2.pvp.feature.RegistrableFeature;
 import io.github.togar2.pvp.feature.config.DefinedFeature;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.component.DataComponents;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.event.player.PlayerTickEvent;
 import net.minestom.server.event.player.PlayerUseItemEvent;
 import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.item.Material;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.component.UseCooldown;
 import net.minestom.server.network.packet.server.play.SetCooldownPacket;
 import net.minestom.server.tag.Tag;
 
@@ -22,11 +24,11 @@ import java.util.Map;
  */
 public class VanillaItemCooldownFeature implements ItemCooldownFeature, RegistrableFeature {
 	public static final DefinedFeature<VanillaItemCooldownFeature> DEFINED = new DefinedFeature<>(
-			FeatureType.ITEM_COOLDOWN, configuration -> new VanillaItemCooldownFeature(),
+			FeatureType.ITEM_COOLDOWN, _ -> new VanillaItemCooldownFeature(),
 			VanillaItemCooldownFeature::initPlayer
 	);
 	
-	public static final Tag<Map<Material, Long>> COOLDOWN_END = Tag.Transient("cooldownEnd");
+	public static final Tag<Map<String, Long>> COOLDOWN_END = Tag.Transient("cooldownEnd");
 	
 	private static void initPlayer(Player player, boolean firstInit) {
 		player.setTag(COOLDOWN_END, new HashMap<>());
@@ -42,14 +44,14 @@ public class VanillaItemCooldownFeature implements ItemCooldownFeature, Registra
 	public void init(EventNode<EntityInstanceEvent> node) {
 		node.addListener(PlayerTickEvent.class, event -> {
 			Player player = event.getPlayer();
-			Map<Material, Long> cooldown = player.getTag(COOLDOWN_END);
+			Map<String, Long> cooldown = player.getTag(COOLDOWN_END);
 			if (cooldown.isEmpty()) return;
 			long time = System.currentTimeMillis();
 			
-			Iterator<Map.Entry<Material, Long>> iterator = cooldown.entrySet().iterator();
+			Iterator<Map.Entry<String, Long>> iterator = cooldown.entrySet().iterator();
 			
 			while (iterator.hasNext()) {
-				Map.Entry<Material, Long> entry = iterator.next();
+				Map.Entry<String, Long> entry = iterator.next();
 				if (entry.getValue() <= time) {
 					iterator.remove();
 					sendCooldownPacket(player, entry.getKey(), 0);
@@ -58,25 +60,50 @@ public class VanillaItemCooldownFeature implements ItemCooldownFeature, Registra
 		});
 		
 		node.addListener(PlayerUseItemEvent.class, event -> {
-			if (hasCooldown(event.getPlayer(), event.getItemStack().material()))
-				event.setCancelled(true);
+            ItemStack stack = event.getItemStack();
+            UseCooldown useCooldown = stack.get(DataComponents.USE_COOLDOWN);
+
+            String cooldownGroup = useCooldown != null && useCooldown.cooldownGroup() != null
+                    ? useCooldown.cooldownGroup()
+                    : stack.material().name();
+
+			if (hasCooldown(event.getPlayer(), cooldownGroup))
+                event.setCancelled(true);
 		});
 	}
 	
 	@Override
-	public boolean hasCooldown(Player player, Material material) {
-		Map<Material, Long> cooldown = player.getTag(COOLDOWN_END);
-		return cooldown.containsKey(material) && cooldown.get(material) > System.currentTimeMillis();
+	public boolean hasCooldown(Player player, String cooldownGroup) {
+		Map<String, Long> cooldown = player.getTag(COOLDOWN_END);
+		return cooldown.containsKey(cooldownGroup) && cooldown.get(cooldownGroup) > System.currentTimeMillis();
 	}
+
+    @Override
+    public boolean hasCooldown(Player player, ItemStack itemStack) {
+        UseCooldown useCooldown = itemStack.get(DataComponents.USE_COOLDOWN);
+        String cooldownGroup = useCooldown != null && useCooldown.cooldownGroup() != null
+                ? useCooldown.cooldownGroup()
+                : itemStack.material().name();
+        return hasCooldown(player, cooldownGroup);
+    }
 	
 	@Override
-	public void setCooldown(Player player, Material material, int ticks) {
-		Map<Material, Long> cooldown = player.getTag(COOLDOWN_END);
-		cooldown.put(material, System.currentTimeMillis() + (long) ticks * MinecraftServer.TICK_MS);
-		sendCooldownPacket(player, material, ticks);
+	public void setCooldown(Player player, String cooldownGroup, int ticks) {
+		Map<String, Long> cooldown = player.getTag(COOLDOWN_END);
+		cooldown.put(cooldownGroup, System.currentTimeMillis() + (long) ticks * MinecraftServer.TICK_MS);
+		sendCooldownPacket(player, cooldownGroup, ticks);
 	}
-	
-	protected void sendCooldownPacket(Player player, Material material, int ticks) {
-		player.getPlayerConnection().sendPacket(new SetCooldownPacket(material.key().asString(), ticks));
+
+    @Override
+    public void setCooldown(Player player, ItemStack itemStack, int ticks) {
+        UseCooldown useCooldown = itemStack.get(DataComponents.USE_COOLDOWN);
+        String cooldownGroup = useCooldown != null && useCooldown.cooldownGroup() != null
+                ? useCooldown.cooldownGroup()
+                : itemStack.material().name();
+        setCooldown(player, cooldownGroup, ticks);
+    }
+
+    protected void sendCooldownPacket(Player player, String cooldownGroup, int ticks) {
+		player.getPlayerConnection().sendPacket(new SetCooldownPacket(cooldownGroup, ticks));
 	}
 }

--- a/src/main/java/io/github/togar2/pvp/feature/projectile/VanillaMiscProjectileFeature.java
+++ b/src/main/java/io/github/togar2/pvp/feature/projectile/VanillaMiscProjectileFeature.java
@@ -84,7 +84,7 @@ public class VanillaMiscProjectileFeature implements MiscProjectileFeature, Regi
 			), player);
 			
 			if (enderpearl) {
-				itemCooldownFeature.setCooldown(player, Material.ENDER_PEARL, 20);
+				itemCooldownFeature.setCooldown(player, Material.ENDER_PEARL.name(), 20);
 			}
 			
 			Pos position = player.getPosition().add(0, player.getEyeHeight(), 0);


### PR DESCRIPTION
Refactored VanillaItemCooldownFeature to instead use the item's USE_COOLDOWN's cooldown group by default, falling back on the material's key in case there's none.
Overloaded API methods to allow to use `ItemStack` as a parameter as well