### PR TITLE
fix: arrow sound cutting out when it hits

### DIFF
--- a/src/main/java/io/github/togar2/pvp/entity/projectile/AbstractArrow.java
+++ b/src/main/java/io/github/togar2/pvp/entity/projectile/AbstractArrow.java
@@ -167,7 +167,8 @@ public abstract class AbstractArrow extends CustomEntityProjectile {
 				this, Objects.requireNonNullElse(shooter, this),
 				null, damage
 		);
-		
+
+		Pos position = getPosition();
 		if (living.damage(damageObj)) {
 			if (entity.getEntityType() == EntityType.ENDERMAN) return false;
 			
@@ -208,12 +209,11 @@ public abstract class AbstractArrow extends CustomEntityProjectile {
 				getViewersAsAudience().playSound(Sound.sound(
 						getSound(), Sound.Source.NEUTRAL,
 						1.0f, 1.2f / (random.nextFloat() * 0.2f + 0.9f)
-				), this);
+				), position.x(), position.y(), position.z());
 			}
 			
 			return getPiercingLevel() <= 0;
 		} else {
-			Pos position = getPosition();
 			setVelocity(getVelocity().mul(-0.5 * 0.2));
 			refreshPosition(position.withYaw(position.yaw() + 170.0f + 20.0f * ThreadLocalRandom.current().nextFloat()));
 			

--- a/src/main/java/io/github/togar2/pvp/entity/projectile/AbstractArrow.java
+++ b/src/main/java/io/github/togar2/pvp/entity/projectile/AbstractArrow.java
@@ -236,7 +236,7 @@ public abstract class AbstractArrow extends CustomEntityProjectile {
 			getViewersAsAudience().playSound(Sound.sound(
 					getSound(), Sound.Source.NEUTRAL,
 					1.0f, 1.2f / (random.nextFloat() * 0.2f + 0.9f)
-			), this);
+			), position.x(), position.y(), position.z());
 		}
 		
 		pickupDelay = 7;


### PR DESCRIPTION
This was caused by the arrow being the emitter of the sound, but when it got killed the client stopped the sound as the emitter wasn't alive anymore